### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @winthrop-intelligence/owners


### PR DESCRIPTION
Adds CODEOWNERS so default-branch protection has an explicit code owner for generated client changes.