### PR TITLE
[codex] Add CLI-backed DeviceToken auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,17 @@ configuration = winthrop_client_python.Configuration(
     host = "http://api-gateway.default.svc.cluster.local"
 )
 
-# The client must configure the authentication and authorization parameters
-# in accordance with the API server security policy.
-# Examples for each auth method are provided below, use the example that
-# satisfies your auth use case.
+# Human users should install the Winthrop CLI and run `winthrop login`.
+configuration.access_token = winthrop_client_python.WinthropClient.DeviceToken.access_token()
 
-# Configure API key authorization: ApiKey
-configuration.api_key['ApiKey'] = os.environ["API_KEY"]
+# Service accounts should continue to use RefreshToken/client_credentials.
+# Client libraries should never handle refresh tokens directly.
 
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['ApiKey'] = 'Bearer'
+# Configure API key authorization: ApiKey, if required by your service account.
+# configuration.api_key['ApiKey'] = os.environ["API_KEY"]
 
-configuration.access_token = os.environ["ACCESS_TOKEN"]
+# Configure a service-account OAuth access token, if required.
+# configuration.access_token = os.environ["ACCESS_TOKEN"]
 
 
 # Enter a context with an instance of the API client
@@ -687,6 +686,21 @@ Class | Method | HTTP request | Description
 <a id="documentation-for-authorization"></a>
 ## Documentation For Authorization
 
+Human users should authenticate with the Winthrop CLI:
+
+```sh
+winthrop login
+```
+
+Then configure this Python client from the CLI-backed device token cache:
+
+```python
+configuration.access_token = winthrop_client_python.WinthropClient.DeviceToken.access_token()
+```
+
+Service accounts should continue to use `WinthropClient.RefreshToken` with
+`client_credentials` or another approved service-account access token flow.
+Client libraries never handle refresh tokens directly.
 
 Authentication schemes defined for the API:
 <a id="ApiKey"></a>
@@ -706,7 +720,5 @@ Authentication schemes defined for the API:
 
 
 ## Author
-
-
 
 

--- a/test/test_api_client_device_token.py
+++ b/test/test_api_client_device_token.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+
+import unittest
+from unittest.mock import Mock, patch
+
+from winthrop_client_python.api_client import ApiClient
+from winthrop_client_python.configuration import Configuration
+from winthrop_client_python.exceptions import UnauthorizedException
+from winthrop_client_python.refresh_token import WinthropClient
+
+
+class Response:
+    def __init__(self, status):
+        self.status = status
+        self.reason = "Unauthorized" if status == 401 else "OK"
+        self.data = b""
+        self.headers = {}
+
+
+class TestApiClientDeviceToken(unittest.TestCase):
+    def setUp(self):
+        WinthropClient.DeviceToken.clear_cache()
+
+    def tearDown(self):
+        WinthropClient.DeviceToken.clear_cache()
+
+    @patch("winthrop_client_python.refresh_token.subprocess.run")
+    def test_401_refreshes_device_token_and_retries_once(self, mock_run):
+        mock_run.side_effect = [
+            Mock(returncode=0, stdout="old-token\n", stderr=""),
+            Mock(returncode=0, stdout="new-token\n", stderr=""),
+        ]
+        configuration = Configuration(access_token=WinthropClient.DeviceToken.access_token())
+        api_client = ApiClient(configuration)
+        api_client.rest_client = Mock()
+        api_client.rest_client.request.side_effect = [Response(401), Response(200)]
+
+        response = api_client.call_api(
+            "GET",
+            "https://example.test/resource",
+            header_params={"Authorization": "Bearer old-token"},
+        )
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(configuration.access_token, "new-token")
+        self.assertEqual(api_client.rest_client.request.call_count, 2)
+        retry_headers = api_client.rest_client.request.call_args.kwargs["headers"]
+        self.assertEqual(retry_headers["Authorization"], "Bearer new-token")
+
+    @patch("winthrop_client_python.refresh_token.subprocess.run")
+    def test_401_retry_raises_auth_error_if_still_401(self, mock_run):
+        mock_run.side_effect = [
+            Mock(returncode=0, stdout="old-token\n", stderr=""),
+            Mock(returncode=0, stdout="new-token\n", stderr=""),
+        ]
+        configuration = Configuration(access_token=WinthropClient.DeviceToken.access_token())
+        api_client = ApiClient(configuration)
+        api_client.rest_client = Mock()
+        api_client.rest_client.request.side_effect = [Response(401), Response(401)]
+
+        with self.assertRaises(UnauthorizedException):
+            api_client.call_api(
+                "GET",
+                "https://example.test/resource",
+                header_params={"Authorization": "Bearer old-token"},
+            )
+
+        self.assertEqual(api_client.rest_client.request.call_count, 2)
+
+    def test_401_does_not_retry_static_access_token(self):
+        configuration = Configuration(access_token="static-token")
+        api_client = ApiClient(configuration)
+        api_client.rest_client = Mock()
+        api_client.rest_client.request.return_value = Response(401)
+
+        response = api_client.call_api(
+            "GET",
+            "https://example.test/resource",
+            header_params={"Authorization": "Bearer static-token"},
+        )
+
+        self.assertEqual(response.status, 401)
+        api_client.rest_client.request.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_device_token.py
+++ b/test/test_device_token.py
@@ -1,0 +1,122 @@
+# coding: utf-8
+
+import subprocess
+import unittest
+from unittest.mock import Mock, patch
+
+from winthrop_client_python.exceptions import UnauthorizedException
+from winthrop_client_python.refresh_token import WinthropClient
+
+
+class TestDeviceToken(unittest.TestCase):
+    def setUp(self):
+        WinthropClient.DeviceToken.clear_cache()
+        WinthropClient.DeviceToken.cli_executable = "winthrop"
+        WinthropClient.DeviceToken.timeout = 10
+
+    def tearDown(self):
+        WinthropClient.DeviceToken.clear_cache()
+        WinthropClient.DeviceToken.cli_executable = "winthrop"
+        WinthropClient.DeviceToken.timeout = 10
+
+    @patch("winthrop_client_python.refresh_token.subprocess.run")
+    def test_access_token_success(self, mock_run):
+        mock_run.return_value = Mock(returncode=0, stdout="token-123\n", stderr="")
+
+        token = WinthropClient.DeviceToken.access_token()
+
+        self.assertEqual(token, "token-123")
+        mock_run.assert_called_once_with(
+            ["winthrop", "token"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+    @patch("winthrop_client_python.refresh_token.subprocess.run")
+    def test_access_token_reuses_cache(self, mock_run):
+        mock_run.return_value = Mock(returncode=0, stdout="cached-token\n", stderr="")
+
+        first = WinthropClient.DeviceToken.access_token()
+        second = WinthropClient.DeviceToken.access_token()
+
+        self.assertEqual(first, "cached-token")
+        self.assertEqual(second, "cached-token")
+        mock_run.assert_called_once()
+
+    @patch("winthrop_client_python.refresh_token.subprocess.run")
+    def test_clear_cache_fetches_next_token(self, mock_run):
+        mock_run.side_effect = [
+            Mock(returncode=0, stdout="first-token\n", stderr=""),
+            Mock(returncode=0, stdout="second-token\n", stderr=""),
+        ]
+
+        first = WinthropClient.DeviceToken.access_token()
+        WinthropClient.DeviceToken.clear_cache()
+        second = WinthropClient.DeviceToken.access_token()
+
+        self.assertEqual(first, "first-token")
+        self.assertEqual(second, "second-token")
+        self.assertEqual(mock_run.call_count, 2)
+
+    @patch("winthrop_client_python.refresh_token.subprocess.run")
+    def test_configurable_executable_and_timeout(self, mock_run):
+        WinthropClient.DeviceToken.cli_executable = "/custom/winthrop"
+        WinthropClient.DeviceToken.timeout = 2
+        mock_run.return_value = Mock(returncode=0, stdout="token\n", stderr="")
+
+        self.assertEqual(WinthropClient.DeviceToken.access_token(), "token")
+
+        mock_run.assert_called_once_with(
+            ["/custom/winthrop", "token"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+
+    @patch("winthrop_client_python.refresh_token.subprocess.run")
+    def test_missing_executable(self, mock_run):
+        mock_run.side_effect = FileNotFoundError()
+
+        with self.assertRaises(UnauthorizedException) as context:
+            WinthropClient.DeviceToken.access_token()
+
+        self.assertIn(
+            "Winthrop CLI is not installed. Install it and run `winthrop login`.",
+            str(context.exception),
+        )
+
+    @patch("winthrop_client_python.refresh_token.subprocess.run")
+    def test_non_zero_exit_surfaces_stderr(self, mock_run):
+        mock_run.return_value = Mock(
+            returncode=1, stdout="", stderr="please run winthrop login\n"
+        )
+
+        with self.assertRaises(UnauthorizedException) as context:
+            WinthropClient.DeviceToken.access_token()
+
+        self.assertIn("please run winthrop login", str(context.exception))
+
+    @patch("winthrop_client_python.refresh_token.subprocess.run")
+    def test_blank_stdout(self, mock_run):
+        mock_run.return_value = Mock(returncode=0, stdout="\n", stderr="")
+
+        with self.assertRaises(UnauthorizedException) as context:
+            WinthropClient.DeviceToken.access_token()
+
+        self.assertIn("blank access token", str(context.exception))
+
+    @patch("winthrop_client_python.refresh_token.subprocess.run")
+    def test_timeout(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(["winthrop", "token"], 10)
+
+        with self.assertRaises(UnauthorizedException) as context:
+            WinthropClient.DeviceToken.access_token()
+
+        self.assertIn("Timed out waiting for Winthrop CLI", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/winthrop_client_python/__init__.py
+++ b/winthrop_client_python/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "ApiResponse",
     "ApiClient",
     "Configuration",
+    "WinthropClient",
     "OpenApiException",
     "ApiTypeError",
     "ApiValueError",
@@ -387,6 +388,7 @@ from winthrop_client_python.api.scraper_api import ScraperApi as ScraperApi
 from winthrop_client_python.api_response import ApiResponse as ApiResponse
 from winthrop_client_python.api_client import ApiClient as ApiClient
 from winthrop_client_python.configuration import Configuration as Configuration
+from winthrop_client_python.refresh_token import WinthropClient as WinthropClient
 from winthrop_client_python.exceptions import OpenApiException as OpenApiException
 from winthrop_client_python.exceptions import ApiTypeError as ApiTypeError
 from winthrop_client_python.exceptions import ApiValueError as ApiValueError

--- a/winthrop_client_python/api_client.py
+++ b/winthrop_client_python/api_client.py
@@ -33,11 +33,7 @@ from winthrop_client_python import rest
 from winthrop_client_python.exceptions import (
     ApiValueError,
     ApiException,
-    BadRequestException,
     UnauthorizedException,
-    ForbiddenException,
-    NotFoundException,
-    ServiceException,
 )
 
 RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
@@ -263,11 +259,57 @@ class ApiClient:
                 post_params=post_params,
                 _request_timeout=_request_timeout,
             )
+            if response_data.status == 401:
+                response_data = self._retry_with_device_token(
+                    response_data,
+                    method,
+                    url,
+                    header_params,
+                    body,
+                    post_params,
+                    _request_timeout,
+                )
 
         except ApiException as e:
             raise e
 
         return response_data
+
+    def _retry_with_device_token(
+        self,
+        response_data,
+        method,
+        url,
+        header_params=None,
+        body=None,
+        post_params=None,
+        _request_timeout=None,
+    ) -> rest.RESTResponse:
+        from winthrop_client_python.refresh_token import WinthropClient
+
+        current_token = self.configuration.access_token
+        if not WinthropClient.DeviceToken.has_cached_token(current_token):
+            return response_data
+
+        WinthropClient.DeviceToken.clear_cache()
+        refreshed_token = WinthropClient.DeviceToken.refresh_access_token()
+        self.configuration.access_token = refreshed_token
+
+        retry_headers = dict(header_params or {})
+        retry_headers["Authorization"] = "Bearer " + refreshed_token
+
+        retry_response = self.rest_client.request(
+            method,
+            url,
+            headers=retry_headers,
+            body=body,
+            post_params=post_params,
+            _request_timeout=_request_timeout,
+        )
+        if retry_response.status == 401:
+            raise UnauthorizedException(http_resp=retry_response)
+
+        return retry_response
 
     def response_deserialize(
         self,
@@ -376,7 +418,8 @@ class ApiClient:
                 obj_dict = obj.__dict__
 
         if isinstance(obj_dict, list):
-            # here we handle instances that can either be a list or something else, and only became a real list by calling to_dict()
+            # here we handle instances that can either be a list or something
+            # else, and only became a real list by calling to_dict()
             return self.sanitize_for_serialization(obj_dict)
 
         return {

--- a/winthrop_client_python/refresh_token.py
+++ b/winthrop_client_python/refresh_token.py
@@ -1,9 +1,12 @@
 import json
+import subprocess
 import threading
 import time
 from typing import Optional, List, Dict, Any
 from urllib.parse import urlencode
 import urllib3
+
+from winthrop_client_python.exceptions import UnauthorizedException
 
 
 class WinthropClient:
@@ -21,13 +24,13 @@ class WinthropClient:
         @classmethod
         def access_token(cls, scopes: Optional[List[str]] = None) -> str:
             cache_key = cls._get_cache_key(scopes)
-            
+
             with cls._cache_lock:
                 cached_token = cls._token_cache.get(cache_key)
-                
+
                 if cached_token is None or time.time() >= cached_token["expires_at"]:
                     cls._generate_access_token(scopes)
-                
+
                 return cls._token_cache[cache_key]["token"]
 
         @classmethod
@@ -44,7 +47,9 @@ class WinthropClient:
             cls._handle_response(response, scopes)
 
         @classmethod
-        def _make_request(cls, scopes: Optional[List[str]] = None) -> urllib3.BaseHTTPResponse:
+        def _make_request(
+            cls, scopes: Optional[List[str]] = None
+        ) -> urllib3.BaseHTTPResponse:
             http = urllib3.PoolManager()
             headers = {"Content-Type": cls.CONTENT_TYPE}
             data = cls._token_params(scopes)
@@ -70,7 +75,11 @@ class WinthropClient:
             return params
 
         @classmethod
-        def _handle_response(cls, response: urllib3.BaseHTTPResponse, scopes: Optional[List[str]] = None) -> None:
+        def _handle_response(
+            cls,
+            response: urllib3.BaseHTTPResponse,
+            scopes: Optional[List[str]] = None,
+        ) -> None:
             if response.status == 200:
                 parsed_response = json.loads(response.data.decode("utf-8"))
                 cache_key = cls._get_cache_key(scopes)
@@ -79,6 +88,97 @@ class WinthropClient:
                     "expires_at": time.time() + int(parsed_response["expires_in"])
                 }
             else:
+                response_data = response.data.decode("utf-8")
                 raise Exception(
-                    f"Failed to retrieve access token: {response.status} - {response.data.decode('utf-8')}"
+                    "Failed to retrieve access token: "
+                    f"{response.status} - {response_data}"
                 )
+
+    class DeviceToken:
+        _token_cache: Dict[str, str] = {}
+        _cache_lock = threading.Lock()
+
+        cli_executable = "winthrop"
+        timeout = 10
+
+        MISSING_CLI_MESSAGE = (
+            "Winthrop CLI is not installed. Install it and run `winthrop login`."
+        )
+
+        @classmethod
+        def access_token(cls, scopes: Optional[List[str]] = None) -> str:
+            cache_key = cls._get_cache_key(scopes)
+
+            with cls._cache_lock:
+                cached_token = cls._token_cache.get(cache_key)
+                if cached_token is None:
+                    cached_token = cls._generate_access_token()
+                    cls._token_cache[cache_key] = cached_token
+
+                return cached_token
+
+        @classmethod
+        def refresh_access_token(cls, scopes: Optional[List[str]] = None) -> str:
+            cache_key = cls._get_cache_key(scopes)
+
+            with cls._cache_lock:
+                token = cls._generate_access_token()
+                cls._token_cache[cache_key] = token
+                return token
+
+        @classmethod
+        def clear_cache(cls) -> None:
+            with cls._cache_lock:
+                cls._token_cache = {}
+
+        @classmethod
+        def has_cached_token(cls, token: Optional[str]) -> bool:
+            if token is None:
+                return False
+
+            with cls._cache_lock:
+                return token in cls._token_cache.values()
+
+        @classmethod
+        def _get_cache_key(cls, scopes: Optional[List[str]] = None) -> str:
+            if scopes is None:
+                return "no_scopes"
+            if len(scopes) == 0:
+                return "empty_scopes"
+            return ",".join(sorted(scopes))
+
+        @classmethod
+        def _generate_access_token(cls) -> str:
+            try:
+                result = subprocess.run(
+                    [cls.cli_executable, "token"],
+                    capture_output=True,
+                    text=True,
+                    timeout=cls.timeout,
+                    check=False,
+                )
+            except FileNotFoundError:
+                raise UnauthorizedException(reason=cls.MISSING_CLI_MESSAGE)
+            except subprocess.TimeoutExpired:
+                raise UnauthorizedException(
+                    reason="Timed out waiting for Winthrop CLI token command."
+            )
+
+            if result.returncode != 0:
+                stderr = (result.stderr or "").strip()
+                if stderr:
+                    raise UnauthorizedException(reason=stderr)
+                raise UnauthorizedException(
+                    reason=(
+                        "Winthrop CLI token command failed with exit code "
+                        f"{result.returncode}."
+                    )
+                )
+
+            token = (result.stdout or "").strip()
+            if not token:
+                raise UnauthorizedException(
+                    reason="Winthrop CLI returned a blank access token."
+                )
+
+            return token


### PR DESCRIPTION
## Summary
- add Winthrop CLI-backed DeviceToken provider for human-user auth
- add in-memory token caching and one-shot 401 refresh/retry behavior
- document winthrop login prerequisite and DeviceToken vs service-account guidance

## Validation
- ./.venv/bin/python -m pytest test/test_device_token.py test/test_api_client_device_token.py -q

## Notes
- Draft PR for review visibility.
- Follow-up needed before merge: move generated-file and README changes into the normal regeneration/patch workflow so they survive client regeneration.